### PR TITLE
fix: adding the home directory var since it also include the bucket

### DIFF
--- a/users.tf
+++ b/users.tf
@@ -28,11 +28,12 @@ resource "aws_iam_role_policy" "sftp_user_policy" {
 }
 
 resource "aws_transfer_user" "sftp_user" {
-  count     = length(var.sftp_users)
-  server_id = aws_transfer_server.sftp.id
-  user_name = var.sftp_users[count.index]["name"]
-  role      = aws_iam_role.sftp_user_role[count.index].arn
-  tags      = var.custom_tags
+  count          = length(var.sftp_users)
+  server_id      = aws_transfer_server.sftp.id
+  user_name      = var.sftp_users[count.index]["name"]
+  home_directory = var.sftp_users[count.index]["home_directory"]
+  role           = aws_iam_role.sftp_user_role[count.index].arn
+  tags           = var.custom_tags
 }
 
 resource "aws_transfer_ssh_key" "sftp_user_key" {


### PR DESCRIPTION
Terraform indicate the home_directory variable as optional but without this variable and the bucket name inside the home_directory, users log in a no man's land. 

To add later on in this module, the Scope-Down Policy. 

https://docs.aws.amazon.com/transfer/latest/userguide/scope-down-policy.html
